### PR TITLE
Add paragraph about reproduciblity when manually installing software

### DIFF
--- a/content/03.discussion.md
+++ b/content/03.discussion.md
@@ -6,6 +6,12 @@ The installation process of bioinformatics research software is typically a mult
 Next is the actual installation, during which the end-user must determine what dependencies are missing and resolve them by installing the required software[5](https://paperpile.com/c/4vBDtY/kjwlC).
 Even in cases where the end-user is familiar with this process, they are typically installing on high-performance clusters where they are constrained by user-level permissions that prevent them from following standard installation procedures.
 
+In addition to being difficult, manual installation of bioinformatics software can lead to irreproducible findings.
+Software versions change over time, sometimes leading to different runtime behavior.
+If an analysis is dependent on recently introduced features of a tool, users trying to reproduce the work with older installations will fail.
+Likewise, even existing functionality can change over time.
+For example, the `input` function in Python 2 is used to run code while in Python 3 it creates a command line prompt [@python-3-changes].
+To prevent such issues without using a package manager, it is necessary to manually keep track of the versions of all dependencies.
 
 
 - root access limitations

--- a/content/03.discussion.md
+++ b/content/03.discussion.md
@@ -2,7 +2,7 @@
 
 ### Existing problems with software distribution and installation
 
-The installation process of bioinformatics research software is typically a multi-step process, starting with the end-user locating and downloading the software. 
+The installation process of bioinformatics research software is typically a multi-step process, starting with the end-user locating and downloading the software.
 Next is the actual installation, during which the end-user must determine what dependencies are missing and resolve them by installing the required software[5](https://paperpile.com/c/4vBDtY/kjwlC).
 Even in cases where the end-user is familiar with this process, they are typically installing on high-performance clusters where they are constrained by user-level permissions that prevent them from following standard installation procedures.
 
@@ -20,16 +20,16 @@ Even in cases where the end-user is familiar with this process, they are typical
 Package managers appeared nearly thirty years ago as software developers sought to automate and standardize the software installation process.
 The earliest package managers (e.g. APT and RPM) were built into Linux operating systems and lacked now common features like dependency resolution.
 Modern package managers are available for all major operating systems, with both integrated and user-installed options available.
-Some are package managers are limited to software written in a specific programming language (e.g. pip distributes software written in Perl), while others are limited to sofware with a particular purpose (e.g. Bioconda distributes omics software).
+Some are package managers are limited to software written in a specific programming language (e.g. pip distributes software written in Python), while others are limited to sofware with a particular purpose (e.g. Bioconda distributes omics software).
 
-Every package managers uses its own package format, which follows the general structure shown in Figure @fig:package-schematic. 
+Every package managers uses its own package format, which follows the general structure shown in Figure @fig:package-schematic.
 
 ![
 **Schematic showing standard package contents.**
 Though the exact contents varies between different package formats, all include the software and relevant metadata necessary to complete installation.
 ](images/package_schematic.png){#fig:package-schematic}
 
-The metadata gives the package manager the necessary information to install the packaged software. 
+The metadata gives the package manager the necessary information to install the packaged software.
 
 To use a package manager, a user instructs the package manager to install software, then the package manager performs all the necessary steps to install the software as shown in Figure @fig:package-manager-usage.
 Assuming the software is not already installed, the package manager retrieves the appropriate package from the repository, a server that stores all of the available packages.
@@ -38,12 +38,12 @@ For most packages, this includes verifying the installation of all dependencies,
 
 ![
 **Standard workflow for installing software via a package manager.**
-The user, usually an admin, asks the package manager to install a specific piece of software. If the software is not already installed, the package manager fetches the approrpriate package from the repository. If any of the dependencies are not already installed, the package manager "loops" through the missing dependencies. Once all dependencies are installed, the original software is installed.  
+The user, usually an admin, asks the package manager to install a specific piece of software. If the software is not already installed, the package manager fetches the approrpriate package from the repository. If any of the dependencies are not already installed, the package manager "loops" through the missing dependencies. Once all dependencies are installed, the original software is installed.
 ](images/package_manager_usage.png){#fig:package-manager-usage width="6in"}
 
-The package manager verifies each dependency by confirming that the dependency is already installed or installing the dependency if it is missing. 
+The package manager verifies each dependency by confirming that the dependency is already installed or installing the dependency if it is missing.
 For missing dependencies, the package manager retrieves the dependency's package from the repository and starts the installation procedure for that package.
-Once all the dependencies are installed, the initially requested software is installed. 
+Once all the dependencies are installed, the initially requested software is installed.
 However, the package manager often goes through several iterations of this process because every dependency can have it's own list of dependencies, in which case each of the dependency's dependencies must be verified through the same process.
 
 In most cases, a package manager is able to install all of the missing dependencies, but there are two relatively common problems that a package manager cannot overcome.
@@ -70,26 +70,26 @@ Administrators often block users from installing software to prevent unwanted ch
 #### Containerization and Virtualization
 
 One approach to sharing software involves virtualization.
-Virtualization is a technique that allows the creation of instances of a software environment, often called 'images'. 
+Virtualization is a technique that allows the creation of instances of a software environment, often called 'images'.
 These images present many benefits for software sharing: only a single image file needs to be downloaded by users, and these image files can have all necessary dependencies for the software pre-installed by the developer, thereby avoiding installation difficulties for users.
 
-Traditional virtual machines emulate operating systems and are run directly on the host's hardware. 
-These are sometimes known as 'type 1 hypervisors' [@Nathan-1]. 
+Traditional virtual machines emulate operating systems and are run directly on the host's hardware.
+These are sometimes known as 'type 1 hypervisors' [@Nathan-1].
 Later, 'type 2' virtualization techniques were developed, running on top of the host operating system (OS) by translating all OS instructions within the guest image [@Nathan-1].
-While these approaches excel in portability, they incur a significant CPU and memory overhead, prompting the development of a more recent approach called Operating System (OS)-Level Virtualization. 
-OS-Level Virtualization runs on top of the same kernel as the host OS, allowing multiple isolated user spaces to be run in parallel and incurring lower CPU, memory, and networking overhead [@Nathan-1,@Nathan-2]. 
-These user spaces, e.g. OS-level images being executed by users, are often called "containers", but also go by a variety of other names. 
+While these approaches excel in portability, they incur a significant CPU and memory overhead, prompting the development of a more recent approach called Operating System (OS)-Level Virtualization.
+OS-Level Virtualization runs on top of the same kernel as the host OS, allowing multiple isolated user spaces to be run in parallel and incurring lower CPU, memory, and networking overhead [@Nathan-1,@Nathan-2].
+These user spaces, e.g. OS-level images being executed by users, are often called "containers", but also go by a variety of other names.
 Examples of this technique include Docker [@Nathan-3], LXC [@Nathan-4], OpenVZ [@Nathan-5], Linux-VServer [@Nathan-6], and rkt [@Nathan-7].
 
-Of these, Docker is perhaps the most widely-used platform. 
-A key aspect of the Docker approach is its modularity: images are stored in a public repository on Docker's website, and it is easy to use an existing image as a "base" to build a new image off of. 
-Docker images are defined by a human-readable, plaintext "Dockerfile" in which the developer specifies whether to build off of a previous base docker image and what additional software libraries and dependencies should be installed. 
-The Dockerfile also serves as an easy-to-read documentation of what dependencies the software is built on [@Nathan-8]. 
+Of these, Docker is perhaps the most widely-used platform.
+A key aspect of the Docker approach is its modularity: images are stored in a public repository on Docker's website, and it is easy to use an existing image as a "base" to build a new image off of.
+Docker images are defined by a human-readable, plaintext "Dockerfile" in which the developer specifies whether to build off of a previous base docker image and what additional software libraries and dependencies should be installed.
+The Dockerfile also serves as an easy-to-read documentation of what dependencies the software is built on [@Nathan-8].
 Docker then builds an image based on the developer’s specifications and this image can be uploaded to the Docker website.
 
-Several limitations exist with Docker and other OS-level virtualization platforms. 
-OS-level images are, as the name implies, limited to a specific host operating system [@Nathan-1,@Nathan-8]. 
-Security concerns have been raised about the vulnerability of containers to compromise, denial of service, and privilege escalation attacks [@Nathan-2]. 
+Several limitations exist with Docker and other OS-level virtualization platforms.
+OS-level images are, as the name implies, limited to a specific host operating system [@Nathan-1,@Nathan-8].
+Security concerns have been raised about the vulnerability of containers to compromise, denial of service, and privilege escalation attacks [@Nathan-2].
 Deployment on high-performance computing clusters is a promising possibility but presents substantial engineering challenges having to do with maximizing resource utilization and allocating resources effectively [@Nathan-9].
 
 ![

--- a/content/90.references.md
+++ b/content/90.references.md
@@ -12,7 +12,7 @@
 @Docker-packages: https://hub.docker.com/search?q=&type=image&page=1
 @EasyBuild-packages: https://easybuild.readthedocs.io/en/latest/version-specific/Supported_software.html
 @Flatpak-packages: https://flathub.org/apps/category/All
-@GNU_Guix-packages: https://guix.gnu.org/packages/ 
+@GNU_Guix-packages: https://guix.gnu.org/packages/
 @omicX-packages: https://omictools.com/software?page=1
 @pip-packages: https://pypi.org/simple/
 @Singularity-packages: https://singularity-hub.org/apps
@@ -31,4 +31,6 @@
 @Nathan-7: https://coreos.com/rkt/
 @Nathan-8: https://dl.acm.org/doi/10.1145/2723872.2723882
 @Nathan-9: https://arxiv.org/abs/1807.06193
+
+@python-3-changes https://docs.python.org/3.0/whatsnew/3.0.html
 </div>

--- a/content/metadata.yaml
+++ b/content/metadata.yaml
@@ -24,28 +24,28 @@ authors:
       -   Department of Clinical Pharmacy, School of Pharmacy, University of Southern California
   - name: Neha Rajkumar
     initials:
-    email: 
-    orcid: 
+    email:
+    orcid:
     github:
     twitter:
     affiliations:
       - Department of Bioengineering, Samueli School of Engineering, University of California, Los Angeles
   - name: Ram Ayyala
     initials:
-    email: 
-    orcid: 
+    email:
+    orcid:
     github:
     twitter:
     affiliations:
       - Department of Neuroscience, School of Life Sciences, University of California Los Angeles
   - name: Heng Li
     initials:
-    email: 
-    orcid: 
+    email:
+    orcid:
     github:
     twitter:
     affiliations:
-      - 
+      -
   - name: Nathan LaPierre
     initials: NRL
     email: nathanl2012@gmail.com
@@ -56,16 +56,16 @@ authors:
       - Computer Science Department, Samueli School of Engineering, University of California, Los Angeles
   - name: André Santos
     initials:
-    email: 
-    orcid: 
+    email:
+    orcid:
     github:
     twitter:
     affiliations:
-      - 
+      -
   - name: Titus Brown
     initials:
     email:
-    orcid: 
+    orcid:
     github:
     twitter:
     affiliations:
@@ -82,16 +82,16 @@ authors:
     orcid: 0000-0002-2250-0669
     github: blawlor
     twitter: blawlor
-    affiliations: 
+    affiliations:
       - Department of Computer Science, Cork Institute of Technology, Cork, Ireland.
   - name: Qiyang Hu
     initials:
     email:
-    orcid: 
+    orcid:
     github:
     twitter:
     affiliations:
-      - 
+      -
   - name: Jaqueline J. Brito
     initials: JJB
     email: britoj@usc.edu
@@ -103,8 +103,16 @@ authors:
   - name: Thiago Mosqueiro
     initials:
     email:
-    orcid: 
+    orcid:
     github:
     twitter:
     affiliations:
-      - 
+      -
+  - name: Benjamin J. Heil
+    initials: BJH
+    email: benheil@pennmedicine.upenn.edu
+    orcid: 0000-0002-2811-1031
+    github: ben-heil
+    twitter: autobencoder
+    affiliations:
+      - Genomics and Computational Biology Graduate Group, Perelman School of Medicine, University of Pennsylvania


### PR DESCRIPTION
Sorry for the long diff, my text editor automatically removes trailing whitespace at the end of lines.

Changes:
- Added a paragraph about issues with reproducibility when manually installing software
- Changed "pip distributes software written in Perl" to "pip distributes software written in Python"
- Added myself to `metadata.yml`